### PR TITLE
add easy to write docker scripts using npm

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,23 +1,29 @@
 {
+  "name": "stats-backend",
+  "private": true,
   "scripts": {
-    "dev": "ts-node-dev src/server.ts",
-    "build": "tsc -p tsconfig.json",
+    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node dist/server.js",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
     "test": "jest -c jest.config.ts -u",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "clean": "rimraf dist || rm -rf dist"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
     "@types/jest": "^29.5.14",
+    "@types/node": "^20.0.0",
     "@types/supertest": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
+    "rimraf": "^6.0.1",
     "supertest": "^7.1.4",
     "ts-jest": "^29.4.4",
+    "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.0"
   },
   "dependencies": {

--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,9 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["node"],         // no jest types during prod build
     "noEmit": false,
-    "outDir": "dist"
+    "rootDir": "src",             // <- compile only app code
+    "outDir": "dist",
+    "types": ["node"]             // no jest types in prod build
   },
   "include": ["src/**/*.ts"],
   "exclude": ["tests", "**/*.test.ts", "dist", "node_modules"]

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -6,7 +6,10 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+
+    "rootDir": ".",               // <- include both src and tests
     "outDir": "dist",
+    "noEmit": true,               // IDE/typecheck only
     "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"],

--- a/apps/plots_py/Dockerfile
+++ b/apps/plots_py/Dockerfile
@@ -1,10 +1,26 @@
-FROM python:3.12.5-slim
+# apps/plots_py/Dockerfile
+
+# --- base image with OS deps ---
+FROM python:3.12-slim AS base
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libfreetype6 libjpeg62-turbo libpng16-16 wget ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+# --- production runtime ---
+FROM base AS runtime
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 EXPOSE 7000
 CMD ["uvicorn","main:app","--host","0.0.0.0","--port","7000"]
+
+# --- test stage (what compose.test.yml targets) ---
+FROM base AS test
+COPY requirements.txt requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements-dev.txt
+COPY . .
+# only run the test runner here
+CMD ["pytest","-q"]

--- a/apps/plots_py/package.json
+++ b/apps/plots_py/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "test": "npm run test:backend && npm run test:py && npm run test:rs",
+    "test:backend": "npm --prefix apps/backend test || echo (no backend tests)",
+    "test:py": "cd apps/plots_py && python -m pytest -q || echo (no python tests)",
+    "test:rs": "echo (rust tests skipped for now)"
+  }
+}

--- a/apps/plots_py/requirements-dev.txt
+++ b/apps/plots_py/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 ruff
 pytest
+httpx

--- a/apps/plots_py/tests/test_health.py
+++ b/apps/plots_py/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_health():
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}

--- a/apps/stats_rs/Dockerfile
+++ b/apps/stats_rs/Dockerfile
@@ -1,16 +1,44 @@
+# --- Build deps & cache cargo registry ---
 FROM rust:1.80-slim AS build
 WORKDIR /src
+
+# 1) Pre-build to cache dependencies
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo "fn main(){}" > src/main.rs && cargo build --release && rm -rf src
+# If this is a workspace, also COPY workspace members' Cargo.toml files here.
+RUN mkdir src && echo "fn main(){}" > src/main.rs \
+    && cargo build --release \
+    && rm -rf src
+
+# 2) Real source & final build
 COPY . .
 RUN cargo build --release
 
-FROM debian:stable-slim
+# --- Test image (used by compose.test.yml) ---
+FROM rust:1.80-slim AS test
+WORKDIR /src
+
+# Repeat the dep-cache trick so test image also benefits
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo "fn main(){}" > src/main.rs \
+    && cargo build --release \
+    && rm -rf src
+
+COPY . .
+# `CMD` runs only when this stage is the target in docker-compose.test.yml
+CMD ["cargo", "test", "--locked"]
+
+# --- Minimal runtime image ---
+FROM debian:stable-slim AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget tini \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
+
+# NOTE: adjust the binary name if your Cargo package isn't "stats_rs"
 COPY --from=build /src/target/release/stats_rs /usr/local/bin/stats_rs
+
+# Non-root user
 USER 65532:65532
 EXPOSE 9000
+
 ENTRYPOINT ["/usr/bin/tini","--"]
 CMD ["stats_rs"]

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,11 @@
+services:
+  plots_py_test:
+    build:
+      context: ../apps/plots_py
+      dockerfile: Dockerfile
+      target: test
+  stats_rs_test:
+    build:
+      context: ../apps/stats_rs
+      dockerfile: Dockerfile
+      target: test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "up": "docker compose -f docker/docker-compose.yml up -d",
+    "down": "docker compose -f docker/docker-compose.yml down -v",
+    "build": "docker compose -f docker/docker-compose.yml build",
+    "test": "docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml up --abort-on-container-exit --exit-code-from plots_py_test plots_py_test stats_rs_test && docker compose -f docker/docker-compose.yml -f docker/docker-compose.test.yml down -v"
+  }
+}


### PR DESCRIPTION
### Summary

Simple Docker scripts for easy deployment:

- npm based Docker compose up, compose down, build, and test commands
- Add test steps to app Dockerfiles and package.json files

### Why

A simple way for developers to run docker commands.

### Notes